### PR TITLE
brisi/cle6: Scalasca-2.3.1-CrayGNU-2016.06

### DIFF
--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.3.1-CrayGNU-2016.06.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.3.1-CrayGNU-2016.06.eb
@@ -1,0 +1,58 @@
+##
+# This is an easyconfig file for EasyBuild, see https://github.com/hpcugent/easybuild
+# Copyright:: Copyright 2013-2016 Juelich Supercomputing Centre, Germany
+# Authors::   Bernd Mohr <b.mohr@fz-juelich.de>
+#             Markus Geimer <m.geimer@fz-juelich.de>
+# License::   3-clause BSD
+#
+# This work is based on experiences from the UNITE project
+# http://apps.fz-juelich.de/unite/
+##
+
+easyblock = 'EB_Score_minus_P'
+
+name = 'Scalasca'
+version = '2.3.1'
+
+homepage = 'http://www.scalasca.org/'
+description = """Scalasca is a software tool that supports the performance optimization of
+ parallel programs by measuring and analyzing their runtime behavior. The analysis identifies
+ potential performance bottlenecks -- in particular those concerning communication and
+ synchronization -- and offers guidance in exploring their causes."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.06'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
+checksums = [ 'a83ced912b9d2330004cb6b9cefa7585' ]
+
+dependencies = [
+    ('libunwind',   '1.1-scorep', '', True),
+    ('Cube',        '4.3.4-debug', '', True),
+    ('OPARI2',      '2.0', '', True),
+    ('OTF2',        '2.0', '', True),
+    ('SIONlib',     '1.6.2-tools', '', True),
+    ('PDT',         '3.22', '', True),
+    ('papi/5.4.3.2', EXTERNAL_MODULE),
+    ('vampir/9.1',   EXTERNAL_MODULE),
+# eb --optarch=broadwell ./Scalasca-2.3.1-CrayGNU-2016.06.eb 
+]
+
+configopts  = ' --with-machine-name=brisi'
+configopts += ' --with-otf2=$EBROOTOTF2/bin'
+configopts += ' --with-opari2=$EBROOTOPARI2/bin'
+configopts += ' --with-cube=$EBROOTCUBE/bin' 
+configopts += ' --disable-gui'
+# configopts += ' --with-binutils=$EBROOTBINUTILS/bin'
+# configopts += ' --with-papi=$EBROOTPAPI'
+
+
+sanity_check_paths = {
+    'files': ["bin/scalasca", "lib/backend/libpearl.replay.a"],
+    'dirs': [],
+}
+
+# Ensure that local metric documentation is found by Cube GUI
+modextrapaths = {'CUBE_DOCPATH': 'share/doc/scalasca/patterns'}
+
+moduleclass = 'perf'


### PR DESCRIPTION
# brisi01:

```
  source /apps/common/easybuild/setup.sh /apps/common/UES/sandbox/jgp/efface
  module unuse /apps/brisi/UES/easybuild/modulefiles

  X=$EASYBUILD_PREFIX/modules/all
  mv $X/libunwind/1.1-scorep  $X/libunwind/.1.1-scorep
  mv $X/OPARI2/2.0  $X/OPARI2/.2.0
  mv $X/OTF2/2.0 $X/OTF2/.2.0
  eb --optarch=broadwell CrayGNU-2016.06.eb
  eb --optarch=broadwell easybuild/easyconfigs/s/Scalasca/Scalasca-2.3.1-CrayGNU-2016.06.eb
```