### PR TITLE
Adding easyconfig file for CP2K release 4.1 with CUDA 8.0 and libxc r…

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.09-cuda-8.0.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.09-cuda-8.0.eb
@@ -1,0 +1,59 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'CP2K'
+version = "4.1"
+
+homepage = 'http://www.cp2k.org/'
+description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
+ simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
+ methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
+ classical pair and many-body potentials. """
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.09'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [SOURCEFORGE_SOURCE]
+
+cudaversion = '8.0'
+versionsuffix = '-cuda-%s' % cudaversion
+
+dependencies = [
+    ('Libint', '1.1.4'),
+    ('libxc', '3.0.0'),
+]
+
+builddependencies = [
+    ('cudatoolkit/%s.34_2.2.5_g8ce7a9a-2.1' %cudaversion, EXTERNAL_MODULE),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
+    ('flex', '2.6.0'),
+    ('Bison', '3.0.4'),
+]
+
+# patch to ./src/dbcsr/libsmm_acc/libcusmm/kernels/cusmm_common.h needed with CUDA 8
+prebuildopts = " sed -i -e '/static/i #if (__CUDACC_VER_MAJOR__<8) || ( defined(__CUDA_ARCH__) && (__CUDA_ARCH__<600) )' -e '/#if defined/i #endif' ./src/dbcsr/libsmm_acc/libcusmm/kernels/cusmm_common.h && "
+# add define flags
+prebuildopts += " sed -i -e 's/^DFLAGS .*/& -D__CUDA_PROFILING -D__FFTSG -D__LIBINT -D__LIBXC -D__GFORTRAN/' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+# add includes
+prebuildopts += " sed -i -e 's#-ffree-form .*#& -I$(EBROOTLIBINT)/include -I$(EBROOTLIBXC)/include#' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+# add libraries 
+prebuildopts += " sed -i -e '/LIBS     +=/a LIBS     += -lcudart -lcublas -lcufft -lrt $(EBROOTLIBINT)/lib/libderiv.a $(EBROOTLIBINT)/lib/libint.a $(EBROOTLIBINT)/lib/libr12.a -lstdc++ -L$(EBROOTLIBXC)/lib -lxcf90 -lxc -lnvToolsExt' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+prebuildopts += " pushd makefiles && "
+
+# don't use parallel make, results in compilation failure
+# because Fortran module files aren't created before they are needed
+parallel = 1
+
+# build type
+buildopts = 'ARCH=CRAY-XC30-gfortran-cuda VERSION=psmp'
+ 
+files_to_copy = [(['./exe/CRAY-XC30-gfortran-cuda/cp2k.psmp'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/cp2k.psmp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libxc/libxc-3.0.0-CrayGNU-2016.09.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-3.0.0-CrayGNU-2016.09.eb
@@ -1,0 +1,34 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libxc'
+version = "3.0.0"
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.09'}
+toolchainopts = {'opt': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://www.tddft.org/programs/octopus/down.php?file=libxc/']
+
+configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared'
+
+# From the libxc mailing list
+# To summarize: expect less tests to fail in libxc 2.0.2, but don't expect
+# a fully working testsuite soon (unless someone wants to volunteer to do
+# it, of course  ) In the meantime, unless the majority of the tests
+# fail, your build should be fine.
+#runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libxc.a', 'lib/libxc.so'],
+    'dirs': ['include'],
+}
+
+parallel = 1
+
+moduleclass = 'chem'
+


### PR DESCRIPTION
…elease 3.0.0: cp2k.psmp tested successfully on Santis CLE 6.0UP02

How to test:
module use /apps/santis/UES/6.0.UP02/sandbox-lm/easybuild/modules/all;
module load CP2K/4.1-CrayGNU-2016.09-cuda-8.0;

Test results in:
/scratch/santis/lucamar/cp2k