### PR TITLE
Update CP2K config file: deleted reference to specific GPU architecture

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.10-cuda-8.0.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.10-cuda-8.0.eb
@@ -40,6 +40,8 @@ prebuildopts += " sed -i -e 's/^DFLAGS .*/& -D__CUDA_PROFILING -D__FFTSG -D__LIB
 prebuildopts += " sed -i -e 's#-ffree-form .*#& -I$(EBROOTLIBINT)/include -I$(EBROOTLIBXC)/include#' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
 # add libraries 
 prebuildopts += " sed -i -e '/LIBS     +=/a LIBS     += -lcudart -lcublas -lcufft -lrt $(EBROOTLIBINT)/lib/libderiv.a $(EBROOTLIBINT)/lib/libint.a $(EBROOTLIBINT)/lib/libr12.a -lstdc++ -L$(EBROOTLIBXC)/lib -lxcf90 -lxc -lnvToolsExt' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+# delete reference to specific GPU architecture
+prebuildopts += " sed -i -e 's/-arch sm_35//' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
 prebuildopts += " pushd makefiles && "
 
 # don't use parallel make, results in compilation failure


### PR DESCRIPTION
The architecture file provided by the developers contained the nvcc flag "-arch=sm_35", which I have removed. The build is now able to run on any supported GPU architecture (sm_20 up to sm_61).