### PR TITLE
Adding easyconfig files for LAMMPS (multicore and hybrid) 2016.10

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.10-cuda-8.0.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.10-cuda-8.0.eb
@@ -1,0 +1,47 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'LAMMPS'
+version = '30Jul16'
+release = 'r15061'
+cudaversion =  '8.0'
+versionsuffix = '-cuda-%s' % cudaversion
+
+homepage = 'http://lammps.sandia.gov/'
+description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.10'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+source_urls = ['https://github.com/lammps/lammps/archive']
+sources = ['%s.tar.gz' % (release)]
+
+maxparallel = 1
+prebuildopts = ' cd ./src && ' 
+prebuildopts += ' make yes-standard yes-user-cg-cmm yes-user-omp yes-user-reaxc yes-gpu && '
+prebuildopts += ' make no-voronoi no-reax no-poems no-meam no-kim && '
+prebuildopts += ' make package-update && '
+# go to folder ./lib/reax and make package reax
+prebuildopts += ' pushd ../lib/reax && make -f Makefile.gfortran && popd && '
+# go to folder ./lib/gpu, create Makefile.gpu and correct file ./lib/gpu/geryon/nvd_device.h
+prebuildopts += ' pushd ../lib/gpu && sed -e "/CUDR_OPTS/d" -e "/CUDA_ARCH/d" Makefile.xk7 > Makefile.gpu && '
+prebuildopts += ' sed -i -e "/CU_COMPUTEMODE_EXCLUSIVE)/ {N; d;}" geryon/nvd_device.h && make -f Makefile.gpu && popd && '
+# create Makefile.omp and correct Makefile.mpi
+prebuildopts += ' sed -e \'s/mpicxx/CC -fopenmp/\' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp && '
+prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
+buildopts = [ ' mpi ', ' omp ' ]
+
+builddependencies = [
+    ('cudatoolkit/%s.34_2.2.5_g8ce7a9a-2.1' %cudaversion, EXTERNAL_MODULE),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
+]
+
+files_to_copy = [(['src/lmp*'], "bin")]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_mpi','bin/lmp_omp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.10.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.10.eb
@@ -1,0 +1,39 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'LAMMPS'
+version = "30Jul16"
+release = 'r15061'
+
+homepage = 'http://lammps.sandia.gov/'
+description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.10'}
+toolchainopts = { 'usempi': True, 'openmp': True , 'dynamic': True }
+
+source_urls = ['https://github.com/lammps/lammps/archive']
+sources = ['%s.tar.gz' % (release)]
+
+maxparallel = 1
+prebuildopts = ' cd ./src && ' 
+prebuildopts += ' make yes-standard yes-user-reaxc yes-user-omp && '
+prebuildopts += ' make no-voronoi no-poems no-meam no-kim no-gpu && '
+prebuildopts += ' make package-update && '
+prebuildopts += ' pushd ../lib/reax && make -f Makefile.gfortran && popd && '
+prebuildopts += ' sed -e \'s/mpicxx/CC -fopenmp/\' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp && '
+prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
+buildopts = [ ' mpi ', ' omp ' ]
+
+builddependencies = [
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
+]
+
+files_to_copy = [(['src/lmp*'], "bin")]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_mpi','bin/lmp_omp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
Last stable release of LAMMPS without and with CUDA 8. Easybuild devel files available below:

/apps/dom/UES/6.0.UP02/sandbox-lm/easybuild/software/LAMMPS/30Jul16-CrayGNU-2016.10/easybuild/LAMMPS-30Jul16-CrayGNU-2016.10-easybuild-devel 

/apps/dom/UES/6.0.UP02/sandbox-lm/easybuild/software/LAMMPS/30Jul16-CrayGNU-2016.10-cuda-8.0/easybuild/LAMMPS-30Jul16-CrayGNU-2016.10-cuda-8.0-easybuild-devel