### PR TITLE
Adding Amer16 support and updating Amber14

### DIFF
--- a/easybuild/easyconfigs/a/Amber/Amber-14-CrayGNU-2016.11-parallel.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-14-CrayGNU-2016.11-parallel.eb
@@ -1,11 +1,12 @@
 # @author: karakasv gppezzi
+# @author: victor holanda rusu
 
 easyblock = 'MakeCp'
 
 name = 'Amber'
 version = '14'
 versionsuffix = '-parallel'
-amber_version='%(version)s'[:2]
+amber_version='%(version)s'
 
 homepage = 'http://ambermd.org/'
 description = 'Assisted Model Building with Energy Refinement'
@@ -13,14 +14,15 @@ description = 'Assisted Model Building with Energy Refinement'
 toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
 toolchainopts = { 'verbose' : False }
 sources = ['Amber%(version)s.tar.gz', 'AmberTools15.tar.bz2']
-patches = ['amber-configure-forceupdate.patch']
 
 dependencies = [ ('bzip2', '1.0.6'),
-                 ('zlib', '1.2.8') ]
+                 ('zlib', '1.2.8'),
+                 ('Python', '2.7.12') ]
 
 builddependencies = [
     ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
     ('cray-netcdf/4.4.1', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
     ('flex', '2.6.0'),
 ]
 
@@ -28,10 +30,10 @@ buildininstalldir = True
 
 configopts = 'gnu'
 
-prebuildopts = 'cd .. && mv amber14/* . && '
+prebuildopts = 'cd .. && mv amber%(version)s/* . && '
 prebuildopts += 'export AMBERHOME=%(builddir)s;'
-
-prebuildopts = prebuildopts + './configure -mpi -noX11 -crayxt5 --with-netcdf $EBROOTNETCDF gnu;'
+prebuildopts += './update_amber --update && '
+prebuildopts += './configure -mpi -noX11 -crayxt5 --with-netcdf $EBROOTNETCDF gnu;'
 
 buildopts = 'install'
 
@@ -46,4 +48,4 @@ modextravars = {
     'AMBERHOME' : '%(builddir)s',
 }
 
-#sanity_check_commands = [('export AMBERHOME=%(builddir)s/amber%(version)s; export LD_LIBRARY_PATH=$AMBERHOME/lib:$LD_LIBRARY_PATH; make', '-C amber%(version)s test')]
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/a/Amber/Amber-16-CrayGNU-2016.11-parallel.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-CrayGNU-2016.11-parallel.eb
@@ -4,8 +4,8 @@
 easyblock = 'MakeCp'
 
 name = 'Amber'
-version = '14'
-versionsuffix = '-serial'
+version = '16'
+versionsuffix = '-parallel'
 amber_version='%(version)s'
 
 homepage = 'http://ambermd.org/'
@@ -13,14 +13,16 @@ description = 'Assisted Model Building with Energy Refinement'
 
 toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
 toolchainopts = { 'verbose' : False }
-sources = ['Amber%(version)s.tar.gz', 'AmberTools15.tar.bz2']
+sources = ['Amber%(version)s.tar.bz2', 'AmberTools%(version)s.tar.bz2']
 
 dependencies = [ ('bzip2', '1.0.6'),
-                 ('zlib', '1.2.8') ]
+                 ('zlib', '1.2.8'),
+                 ('Python', '2.7.12') ]
 
 builddependencies = [
     ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
     ('cray-netcdf/4.4.1', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
     ('flex', '2.6.0'),
 ]
 
@@ -31,14 +33,14 @@ configopts = 'gnu'
 prebuildopts = 'cd .. && mv amber%(version)s/* . && '
 prebuildopts += 'export AMBERHOME=%(builddir)s;'
 prebuildopts += './update_amber --update && '
-prebuildopts += './configure -noX11 -crayxt5 --with-netcdf $EBROOTNETCDF gnu;'
+prebuildopts += './configure -mpi -noX11 -crayxt5 --with-netcdf $EBROOTNETCDF gnu;'
 
 buildopts = 'install'
 
 files_to_copy = []
 
 sanity_check_paths = {
-    'files' : [ 'bin/pmemd' ],
+    'files' : [ 'bin/pmemd.MPI' ],
     'dirs'  : [],
 }
 

--- a/easybuild/easyconfigs/a/Amber/Amber-16-CrayGNU-2016.11-serial.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-CrayGNU-2016.11-serial.eb
@@ -4,7 +4,7 @@
 easyblock = 'MakeCp'
 
 name = 'Amber'
-version = '14'
+version = '16'
 versionsuffix = '-serial'
 amber_version='%(version)s'
 
@@ -13,14 +13,16 @@ description = 'Assisted Model Building with Energy Refinement'
 
 toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
 toolchainopts = { 'verbose' : False }
-sources = ['Amber%(version)s.tar.gz', 'AmberTools15.tar.bz2']
+sources = ['Amber%(version)s.tar.bz2', 'AmberTools%(version)s.tar.bz2']
 
 dependencies = [ ('bzip2', '1.0.6'),
-                 ('zlib', '1.2.8') ]
+                 ('zlib', '1.2.8'),
+                 ('Python', '2.7.12') ]
 
 builddependencies = [
     ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
     ('cray-netcdf/4.4.1', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
     ('flex', '2.6.0'),
 ]
 


### PR DESCRIPTION
Add CPU serial and parallel versions of Amber 14 and 16
And drop the patch to install to Amber 14

`eb -f Amber-16-CrayGNU-2016.11-parallel.eb`
== temporary log file in case of crash /tmp/eb-yivV6h/easybuild-XmPsxO.log
== processing EasyBuild easyconfig $HOME/easybuild/commits/tools/easybuild/easyconfigs/a/Amber/Amber-16-CrayGNU-2016.11-parallel.eb
== building and installing Amber/16-CrayGNU-2016.11-parallel...
== fetching files...
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
== building...
 == testing...
== installing...
== taking care of extensions...
== postprocessing...
== sanity checking...
== cleaning up...
== creating module...
== permissions...
== packaging...
== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /apps/dom/UES/6.0.UP02/sandbox-vh/easybuild/software/Amber/16-CrayGNU-2016.11-parallel/easybuild/easybuild-Amber-16-20161122.090806.log
== Build succeeded for 1 out of 1
== Temporary log file(s) /tmp/eb-yivV6h/easybuild-XmPsxO.log* have been removed.
== Temporary directory /tmp/eb-yivV6h has been removed.


`eb -f Amber-16-CrayGNU-2016.11-serial.eb`    
== temporary log file in case of crash /tmp/eb-FeSXyg/easybuild-rpcXWk.log
== processing EasyBuild easyconfig $HOME/easybuild/commits/tools/easybuild/easyconfigs/a/Amber/Amber-16-CrayGNU-2016.11-serial.eb
== building and installing Amber/16-CrayGNU-2016.11-serial...
== fetching files...
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
== building...
== testing...
== installing...
== taking care of extensions...
== postprocessing...
== sanity checking...
== cleaning up...
== creating module...
== permissions...
== packaging...
== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /apps/dom/UES/6.0.UP02/sandbox-vh/easybuild/software/Amber/16-CrayGNU-2016.11-serial/easybuild/easybuild-Amber-16-20161122.091754.log
== Build succeeded for 1 out of 1
== Temporary log file(s) /tmp/eb-FeSXyg/easybuild-rpcXWk.log* 


`eb -f Amber-14-CrayGNU-2016.11-parallel.eb ` 
== temporary log file in case of crash /tmp/eb-8BOV6M/easybuild-QbzIIx.log
== processing EasyBuild easyconfig $HOME/easybuild/commits/tools/easybuild/easyconfigs/a/Amber/Amber-14-CrayGNU-2016.11-parallel.eb
== building and installing Amber/14-CrayGNU-2016.11-parallel...
== fetching files...
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
== building...
== testing...
== installing...
== taking care of extensions...
== postprocessing...
== sanity checking...
== cleaning up...
== creating module...
== permissions...
== packaging...
== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /apps/dom/UES/6.0.UP02/sandbox-vh/easybuild/software/Amber/14-CrayGNU-2016.11-parallel/easybuild/easybuild-Amber-14-20161122.093210.log
== Build succeeded for 1 out of 1
== Temporary log file(s) /tmp/eb-8BOV6M/easybuild-QbzIIx.log* have been removed.
== Temporary directory /tmp/eb-8BOV6M has been removed.



`eb -f Amber-14-CrayGNU-2016.11-serial.eb` 
== temporary log file in case of crash /tmp/eb-W3kcrF/easybuild-i86Mod.log
== processing EasyBuild easyconfig $HOME/easybuild/commits/tools/easybuild/easyconfigs/a/Amber/Amber-14-CrayGNU-2016.11-serial.eb
== building and installing Amber/14-CrayGNU-2016.11-serial...
== fetching files...
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
== building...
== testing...
== installing...
== taking care of extensions...
== postprocessing...
== sanity checking...
== cleaning up...
== creating module...
== permissions...
== packaging...
== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /apps/dom/UES/6.0.UP02/sandbox-vh/easybuild/software/Amber/14-CrayGNU-2016.11-serial/easybuild/easybuild-Amber-14-20161122.095740.log
== Build succeeded for 1 out of 1
== Temporary log file(s) /tmp/eb-W3kcrF/easybuild-i86Mod.log* have been removed.
== Temporary directory /tmp/eb-W3kcrF has been removed.
